### PR TITLE
No need to special case `localhost`

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,5 @@ module.exports = function (url) {
 		throw new TypeError('Expected a string');
 	}
 
-	return url.trim()
-		.replace(/^localhost/, 'http://$&')
-		.replace(/^(?!(?:\w+:)?\/\/)/, 'http://');
+	return url.trim().replace(/^(?!(?:\w+:)?\/\/)/, 'http://');
 };


### PR DESCRIPTION
It'll already be handled by the second rule. Plus, it's a kind of jank regexp. 
